### PR TITLE
Setting yAxis for radar Chart crashing on iOS

### DIFF
--- a/ios/ReactNativeCharts/radar/RNRadarChartView.swift
+++ b/ios/ReactNativeCharts/radar/RNRadarChartView.swift
@@ -33,7 +33,18 @@ class RNRadarChartView: RNYAxisChartViewBase {
         fatalError("init(coder:) has not been implemented")
     }
     
- 
+    override func setYAxis(_ config: NSDictionary) {
+        let json = BridgeUtils.toJson(config)
+    
+        let yAxis = chart.yAxis;
+    
+        setCommonAxisConfig(yAxis, config: json)
+    
+        if json["position"].string != nil {
+            yAxis.labelPosition = BridgeUtils.parseYAxisLabelPosition(json["position"].stringValue)
+        }
+    }
+    
     func setSkipWebLineCount(_ count: Int) {
         _chart.skipWebLineCount = count
     }


### PR DESCRIPTION
This commit will fix the "subclass should override setYAxis" Error for Radar Charts.